### PR TITLE
Normalize Repos into their own table

### DIFF
--- a/app/controllers/github_payloads_controller.rb
+++ b/app/controllers/github_payloads_controller.rb
@@ -1,7 +1,8 @@
 class GithubPayloadsController < ApplicationController
   def create
     if pr_is_new?
-      PullRequest.create(pr_params)
+      repo = Repo.find_or_create_by!(pr_params.delete(:repo_params))
+      repo.pull_requests.create!(pr_params)
     end
 
     render nothing: true
@@ -14,10 +15,10 @@ class GithubPayloadsController < ApplicationController
   end
 
   def parser
-    @_parser ||= PayloadParser.new(params[:payload])
+    @_parser ||= PayloadParser.new(params[:payload], RepoPayloadParser.new)
   end
 
   def pr_params
-    parser.params
+    @pr_params ||= parser.params
   end
 end

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -1,6 +1,7 @@
 class PullRequest < ActiveRecord::Base
   validates :github_issue_id, presence: true
   validates :github_url, presence: true
-  validates :repo_name, presence: true
   validates :status, presence: true
+
+  belongs_to :repo, required: true
 end

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -1,0 +1,6 @@
+class Repo < ActiveRecord::Base
+  validates :full_name, presence: true
+  validates :github_url, presence: true
+
+  has_many :pull_requests
+end

--- a/app/services/payload_parser.rb
+++ b/app/services/payload_parser.rb
@@ -1,6 +1,7 @@
 class PayloadParser
-  def initialize(payload)
+  def initialize(payload, repo_payload_parser)
     @payload = payload
+    @repo_payload_parser = repo_payload_parser
   end
 
   def action
@@ -11,9 +12,13 @@ class PayloadParser
     {
       github_issue_id: github_issue_id,
       github_url: github_url,
-      repo_name: repo_name,
+      repo_params: repo_params,
     }
   end
+
+  protected
+
+  attr_reader :repo_payload_parser
 
   private
 
@@ -25,8 +30,8 @@ class PayloadParser
     payload["pull_request"]["html_url"]
   end
 
-  def repo_name
-    payload["pull_request"]["head"]["repo"]["full_name"]
+  def repo_params
+    repo_payload_parser.parse(payload["pull_request"]["head"]["repo"])
   end
 
   def payload

--- a/app/services/repo_payload_parser.rb
+++ b/app/services/repo_payload_parser.rb
@@ -1,0 +1,8 @@
+class RepoPayloadParser
+  def parse(payload)
+    {
+      full_name: payload["full_name"],
+      github_url: payload["html_url"],
+    }
+  end
+end

--- a/db/migrate/20141211220550_create_repos.rb
+++ b/db/migrate/20141211220550_create_repos.rb
@@ -1,0 +1,18 @@
+class CreateRepos < ActiveRecord::Migration
+  def change
+    change_table :pull_requests do |t|
+      t.belongs_to :repo, null: false, index: true
+    end
+
+    revert do
+      add_column :pull_requests, :repo_name, :string, null: false
+    end
+
+    create_table :repos do |t|
+      t.string :full_name
+      t.string :github_url
+    end
+
+    add_foreign_key :pull_requests, :repos
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141211190456) do
+ActiveRecord::Schema.define(version: 20141211220550) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,10 +37,17 @@ ActiveRecord::Schema.define(version: 20141211190456) do
     t.datetime "updated_at",                               null: false
     t.integer  "github_issue_id",                          null: false
     t.string   "github_url",                               null: false
-    t.string   "repo_name",                                null: false
     t.string   "status",          default: "needs review", null: false
+    t.integer  "repo_id",                                  null: false
   end
 
+  add_index "pull_requests", ["repo_id"], name: "index_pull_requests_on_repo_id", using: :btree
   add_index "pull_requests", ["status"], name: "index_pull_requests_on_status", using: :btree
 
+  create_table "repos", force: true do |t|
+    t.string "full_name"
+    t.string "github_url"
+  end
+
+  add_foreign_key "pull_requests", "repos"
 end

--- a/spec/controllers/github_payloads_controller_spec.rb
+++ b/spec/controllers/github_payloads_controller_spec.rb
@@ -7,6 +7,21 @@ describe GithubPayloadsController do
         send_pull_request_payload(action: "opened")
         expect(last_pull_request.status).to eq("needs review")
       end
+
+      it "creates a new Repo" do
+        send_pull_request_payload(action: "opened")
+        expect(last_pull_request.repo.full_name).to eq("baxterthehacker/public-repo")
+      end
+
+      it "attaches to an existing repo if one exists" do
+        repo = create(
+          :repo,
+          full_name: "baxterthehacker/public-repo",
+          github_url: "https://github.com/baxterthehacker/public-repo",
+        )
+        send_pull_request_payload(action: "opened")
+        expect(last_pull_request.repo_id).to eq(repo.id)
+      end
     end
 
     describe "when the action is not 'opened'" do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :repo do
+    full_name "thoughtbot/pr-tool"
+    github_url "https://github.com/thoughtbot/pr-tool"
+  end
+end

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -3,6 +3,5 @@ require "rails_helper"
 describe PullRequest do
   it { should validate_presence_of(:github_issue_id) }
   it { should validate_presence_of(:github_url) }
-  it { should validate_presence_of(:repo_name) }
   it { should validate_presence_of(:status) }
 end

--- a/spec/services/repo_payload_parser_spec.rb
+++ b/spec/services/repo_payload_parser_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+require 'services/repo_payload_parser'
+
+describe RepoPayloadParser do
+  it("extracts the full name and github url") do
+    payload = {
+      "other_stuff" => "should not be present",
+      "full_name" => "thoughtbot/pr-tool",
+      "html_url" => "https://github.com/thoughtbot/pr-tool",
+    }
+    parser = RepoPayloadParser.new
+
+    expect(parser.parse(payload)).to eq({
+      full_name: "thoughtbot/pr-tool",
+      github_url: "https://github.com/thoughtbot/pr-tool",
+    })
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,3 +14,5 @@ RSpec.configure do |config|
 end
 
 WebMock.disable_net_connect!(allow_localhost: true)
+
+$LOAD_PATH.unshift(File.expand_path("../../app", __FILE__))


### PR DESCRIPTION
We're going to end up with a _ton_ of prefixes for things like repos
which have multiple attributes that we need, if we leave them in the
same table.
