### PR TITLE
Remove fallback border-color

### DIFF
--- a/app/assets/stylesheets/_tags.scss
+++ b/app/assets/stylesheets/_tags.scss
@@ -77,6 +77,7 @@ $tags: (
 
   &.is-active {
     background: $tag-fallback-color;
+    border-color: transparent;
     box-shadow: $base-box-shadow;
 
     .tag-badge {


### PR DESCRIPTION
The fallback tag was inheriting a dark-blue border-color, causing it to
look smaller than its neighbors
# test
