### PR TITLE
Do not create a new PR if there are no tags

### DIFF
--- a/app/actions/create_new_pr.rb
+++ b/app/actions/create_new_pr.rb
@@ -4,7 +4,8 @@ class CreateNewPr
   end
 
   def self.matches(payload_parser, *)
-    payload_parser.action == "opened"
+    payload_parser.action == "opened" &&
+      TagParser.new.parse(payload_parser.body).any?
   end
 
   def call

--- a/spec/actions/create_new_pr_spec.rb
+++ b/spec/actions/create_new_pr_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe CreateNewPr do
+  describe ".matches" do
+    context "when there are no tags" do
+      it "is false" do
+        parser = double(
+          :parser,
+          action: "opened",
+          body: "There are no tags here",
+        )
+
+        expect(CreateNewPr.matches(parser, nil)).to be false
+      end
+    end
+  end
+end

--- a/spec/controllers/github_payloads_controller_spec.rb
+++ b/spec/controllers/github_payloads_controller_spec.rb
@@ -41,7 +41,7 @@ describe GithubPayloadsController do
 
     describe "when the action is 'opened'" do
       it "creates a new PullRequest" do
-        send_pull_request_payload(action: "opened")
+        send_pull_request_payload(action: "opened", body: "#rails")
         expect(last_pull_request.status).to eq("needs review")
       end
 
@@ -62,11 +62,6 @@ describe GithubPayloadsController do
         tag = Tag.create!(name: "rails")
         send_pull_request_payload(action: "opened", body: "A request #rails")
         expect(Tag.pluck(:id)).to eq ([tag.id])
-      end
-
-      it "does not default to any tags" do
-        send_pull_request_payload(action: "opened", body: "A request with no tags")
-        expect(last_pull_request.tags.map(&:name)).to eq([])
       end
 
       it "posts to slack" do


### PR DESCRIPTION
A lot of projects are running beggar and people forgot to put tags on their PRs. This will not create a new PR in the beggar UI if there are no tags. This will cut down on irrelvant PRs in the Web UI.
