### PR TITLE
Creates a project with a default channel

### DIFF
--- a/app/admin/project.rb
+++ b/app/admin/project.rb
@@ -1,0 +1,3 @@
+ActiveAdmin.register Project do
+  permit_params :name, :default_channel_id, :github_url
+end

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -3,6 +3,7 @@ class Channel < ActiveRecord::Base
   validates :name, uniqueness: { scope: :webhook_url }
   validates :webhook_url, presence: true
 
+  has_many :projects, as: :default_channel, dependent: :destroy
   has_many :tags, dependent: :destroy
   has_and_belongs_to_many :active_pull_requests, -> { active }, class_name: "PullRequest"
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,0 +1,7 @@
+class Project < ActiveRecord::Base
+  validates :default_channel, presence: true
+  validates :github_url, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: true
+
+  belongs_to :default_channel, class_name: "Channel"
+end

--- a/app/services/payload_parser.rb
+++ b/app/services/payload_parser.rb
@@ -43,6 +43,10 @@ class PayloadParser
     }
   end
 
+  def repo_github_url
+    pull_request["head"]["repo"]["html_url"]
+  end
+
   protected
 
   attr_reader :headers, :payload
@@ -59,10 +63,6 @@ class PayloadParser
 
   def repo_name
     pull_request["head"]["repo"]["full_name"]
-  end
-
-  def repo_github_url
-    pull_request["head"]["repo"]["html_url"]
   end
 
   def title

--- a/app/services/project_matcher.rb
+++ b/app/services/project_matcher.rb
@@ -1,0 +1,5 @@
+class ProjectMatcher
+  def self.match(github_url)
+    Project.where(github_url: github_url)
+  end
+end

--- a/db/migrate/20150313144216_create_project.rb
+++ b/db/migrate/20150313144216_create_project.rb
@@ -1,0 +1,16 @@
+class CreateProject < ActiveRecord::Migration
+  def change
+    create_table :projects do |t|
+      t.string :name, null: false, unique: true
+      t.string :github_url, null: false, unique: true
+      t.integer :default_channel_id, null: false
+    end
+
+    add_foreign_key(
+      :projects,
+      :channels,
+      column: :default_channel_id,
+      on_delete: :cascade
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,26 +11,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150304195244) do
+ActiveRecord::Schema.define(version: 20150313144216) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "channels", force: true do |t|
+  create_table "channels", force: :cascade do |t|
     t.string "name",        null: false
     t.string "webhook_url", null: false
   end
 
   add_index "channels", ["name"], name: "index_channels_on_name", using: :btree
 
-  create_table "channels_pull_requests", force: true do |t|
+  create_table "channels_pull_requests", force: :cascade do |t|
     t.integer "channel_id"
     t.integer "pull_request_id"
   end
 
   add_index "channels_pull_requests", ["channel_id", "pull_request_id"], name: "index_channels_pull_requests_on_channel_id_and_pull_request_id", unique: true, using: :btree
 
-  create_table "delayed_jobs", force: true do |t|
+  create_table "delayed_jobs", force: :cascade do |t|
     t.integer  "priority",   default: 0, null: false
     t.integer  "attempts",   default: 0, null: false
     t.text     "handler",                null: false
@@ -46,7 +46,13 @@ ActiveRecord::Schema.define(version: 20150304195244) do
 
   add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
 
-  create_table "pull_requests", force: true do |t|
+  create_table "projects", force: :cascade do |t|
+    t.string  "name",               null: false
+    t.string  "github_url",         null: false
+    t.integer "default_channel_id", null: false
+  end
+
+  create_table "pull_requests", force: :cascade do |t|
     t.datetime "created_at",                                                                          null: false
     t.datetime "updated_at",                                                                          null: false
     t.string   "github_url",                                                                          null: false
@@ -64,11 +70,12 @@ ActiveRecord::Schema.define(version: 20150304195244) do
 
   add_index "pull_requests", ["status"], name: "index_pull_requests_on_status", using: :btree
 
-  create_table "tags", force: true do |t|
+  create_table "tags", force: :cascade do |t|
     t.string  "name",       null: false
     t.integer "channel_id", null: false
   end
 
   add_index "tags", ["name"], name: "index_tags_on_name", using: :btree
 
+  add_foreign_key "projects", "channels", column: "default_channel_id", on_delete: :cascade
 end

--- a/spec/actions/create_new_pr_spec.rb
+++ b/spec/actions/create_new_pr_spec.rb
@@ -8,9 +8,99 @@ describe CreateNewPr do
           :parser,
           action: "opened",
           body: "There are no tags here",
+          repo_github_url: "http://example.com/"
         )
 
         expect(CreateNewPr.matches(parser, nil)).to be false
+      end
+    end
+
+    context "when there is a project" do
+      it "is true with tags" do
+        project_url = "http://example.com/thoughtbot/beggar"
+        create(:project, github_url: project_url)
+        parser = double(
+          :parser,
+          action: "opened",
+          body: "#rails",
+          repo_github_url: project_url
+        )
+
+        expect(CreateNewPr.matches(parser, nil)).to be true
+      end
+
+      it "is true without tags" do
+        project_url = "https://github.com/thoughtbot/beggar"
+        create(:project, github_url: project_url)
+        parser = double(
+          :parser,
+          action: "opened",
+          body: "No tags, no tags",
+          repo_github_url: project_url
+        )
+
+        expect(CreateNewPr.matches(parser, nil)).to be true
+      end
+    end
+  end
+
+  describe ".channels" do
+    context "when there is a project" do
+      it "includes the project default channel and any tags" do
+        rails_channel = create(:channel, tag_name: "rails")
+        design_channel = create(:channel, tag_name: "design")
+        project_channel = create(:channel, name: "project")
+
+        project_url = "https://github.com/thoughtbot/beggar"
+        create(
+          :project,
+          github_url: project_url,
+          default_channel: project_channel
+        )
+
+        channels_list = {
+          channels: [
+            rails_channel,
+            design_channel,
+            project_channel
+          ]
+        }
+
+        parser = double(
+          :parser,
+          action: "opened",
+          body: "#rails #design",
+          params: spy(Hash.new),
+          repo_github_url: project_url
+        )
+
+        pr_creator = CreateNewPr.new(parser, nil)
+        allow(pr_creator).to receive(:post_to_slack)
+
+        pr_creator.call
+
+        expect(parser.params).to have_received(:merge).with(channels_list)
+      end
+    end
+
+    context "when there isn't a project" do
+      it "includes channels based on tags" do
+        rails_channel = create(:channel, tag_name: "rails")
+        design_channel = create(:channel, tag_name: "design")
+        channels_hash = { channels: [rails_channel, design_channel] }
+        parser = double(
+          :parser,
+          action: "opened",
+          body: "#rails #design",
+          params: spy(Hash.new),
+          repo_github_url: "_"
+        )
+        pr_creator = CreateNewPr.new(parser, nil)
+        allow(pr_creator).to receive(:post_to_slack)
+
+        pr_creator.call
+
+        expect(parser.params).to have_received(:merge).with(channels_hash)
       end
     end
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -14,6 +14,12 @@ FactoryGirl.define do
     end
   end
 
+  factory :project do
+    sequence(:name) { |n| "project#{n}" }
+    sequence(:github_url) { |n| "http://example.com/thoughtbot/project#{n}" }
+    association :default_channel, factory: :channel
+  end
+
   factory :pull_request do
     sequence(:github_url) {|n| "https://github.com/thoughtbot/stuff/pulls/#{n}"}
     repo_github_url { "https://github.com/#{repo_name}" }

--- a/spec/models/channel_spec.rb
+++ b/spec/models/channel_spec.rb
@@ -4,6 +4,7 @@ describe Channel do
   it { should validate_presence_of(:name) }
   it { should validate_presence_of(:webhook_url) }
 
+  it { should have_many(:projects).dependent(:destroy) }
   it { should have_many(:tags).dependent(:destroy) }
   it { should have_and_belong_to_many(:active_pull_requests) }
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+describe Project do
+  subject { FactoryGirl.build(:project) }
+  it { should validate_presence_of(:name) }
+  it { should validate_uniqueness_of(:name) }
+  it { should belong_to(:default_channel) }
+  it { should validate_presence_of(:default_channel) }
+  it { should validate_presence_of(:github_url) }
+  it { should validate_uniqueness_of(:github_url) }
+end

--- a/spec/services/project_matcher_spec.rb
+++ b/spec/services/project_matcher_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+require "services/project_matcher"
+
+describe ProjectMatcher do
+  it "matches when a project has the same github repo name as provided text" do
+    url = "http://example.com/thoughtbot/beggar"
+    create(:project, github_url: url)
+
+    result = ProjectMatcher.match(url)
+
+    expect(result.first.github_url).to eq(url)
+  end
+end


### PR DESCRIPTION
- When a project is created, every PR against a project will go into a default
  project channel whether or not the PR is tagged
- Assumption is that a project-specific channel will be setup, but nothing
  forces this
  - You could, for instance, associate a project with an existing channel
- Projects have one channel
- A channel could have more than one project, but that's just a matter of how
  the relationship is set-up than an expectation
  - My thinking is one channel might have multiple projects since projects have
    a 1:1 relationship with GitHub repos and a channel could be the landing spot
    for multiple repositories
  - e.g. headquarters-api, headquarters-ember

Tags: #rails

![screenshot 2015-03-20 15 31 29](https://cloud.githubusercontent.com/assets/26247/6759742/ca6ef6f2-cf18-11e4-84e8-ae96ea85bf82.png)
![screenshot 2015-03-20 15 32 05](https://cloud.githubusercontent.com/assets/26247/6759741/ca6eebd0-cf18-11e4-9bab-741dd4bf9510.png)
