### PR TITLE
Store the original tags for a pull request

### DIFF
--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -11,6 +11,7 @@ class PullRequest < ActiveRecord::Base
   validates :avatar_url, presence: true
 
   has_and_belongs_to_many :channels
+  has_and_belongs_to_many :tags
 
   time_for_a_boolean :reposted
 
@@ -36,10 +37,6 @@ class PullRequest < ActiveRecord::Base
 
   def self.updated_before(timestamp)
     where("updated_at <= ?", timestamp)
-  end
-
-  def tags
-    channels.flat_map(&:tags)
   end
 
   def tag_names

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -5,4 +5,6 @@ class Tag < ActiveRecord::Base
   validates :name, uniqueness: true
 
   belongs_to :channel
+
+  has_and_belongs_to_many :pull_requests
 end

--- a/db/migrate/20150714160637_create_tags_habtm.rb
+++ b/db/migrate/20150714160637_create_tags_habtm.rb
@@ -1,0 +1,10 @@
+class CreateTagsHabtm < ActiveRecord::Migration
+  def change
+    create_table :pull_requests_tags do |t|
+      t.belongs_to :pull_request
+      t.belongs_to :tag
+    end
+
+    add_index :pull_requests_tags, [:pull_request_id, :tag_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150313144216) do
+ActiveRecord::Schema.define(version: 20150714160637) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,6 +69,13 @@ ActiveRecord::Schema.define(version: 20150313144216) do
   end
 
   add_index "pull_requests", ["status"], name: "index_pull_requests_on_status", using: :btree
+
+  create_table "pull_requests_tags", force: :cascade do |t|
+    t.integer "pull_request_id"
+    t.integer "tag_id"
+  end
+
+  add_index "pull_requests_tags", ["pull_request_id", "tag_id"], name: "index_pull_requests_tags_on_pull_request_id_and_tag_id", unique: true, using: :btree
 
   create_table "tags", force: :cascade do |t|
     t.string  "name",       null: false

--- a/spec/features/user_views_prs_spec.rb
+++ b/spec/features/user_views_prs_spec.rb
@@ -47,7 +47,7 @@ feature "User views PRs" do
   scenario "viewing tags for the current pr" do
     create(
       :pull_request,
-      channels: [channel("Rails"), channel("Ember")]
+      tags: [tag("Rails"), tag("Ember")],
     )
 
     visit root_path
@@ -151,5 +151,9 @@ feature "User views PRs" do
 
   def channel(name)
     create(:channel, name: name, tag_name: name)
+  end
+
+  def tag(name)
+    create(:tag, name: name)
   end
 end


### PR DESCRIPTION
Previously, if you enter a tag, we would attach that tag's channel to the PR. This would cause the posted pull request in slack to include all tags for that channel:

For example, this PR was only tagged as `#ember`:
<img width="477" alt="monosnap 2015-07-14 13-50-44" src="https://cloud.githubusercontent.com/assets/89965/8680438/550e2d5c-2a2f-11e5-9b01-12fc14543cf9.png">

This PR moves the tags to their own association on the model, independent on the channel so that the slack post makes more sense.
