### PR TITLE
Use a single webhook URL for posting to Slack

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -6,3 +6,4 @@ GITHUB_SECRET_KEY=github_secret
 GITHUB_CLIENT_ID=bdc4d3930952e5df9f72
 GITHUB_CLIENT_SECRET=c20a3fd60154b57dd38009de2007a96381bfdf15
 WEBHOOK_URL=https://example.com
+SLACK_POST_WEBHOOK_URL=https://hooks.slack.com/services/abc/123

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -1,7 +1,6 @@
 class Channel < ActiveRecord::Base
   validates :name, presence: true
-  validates :name, uniqueness: { scope: :webhook_url }
-  validates :webhook_url, presence: true
+  validates :name, uniqueness: true
 
   has_many :projects, as: :default_channel, dependent: :destroy
   has_many :tags, dependent: :destroy

--- a/app/services/webhook_notifier.rb
+++ b/app/services/webhook_notifier.rb
@@ -7,9 +7,7 @@ class WebhookNotifier
   end
 
   def send_notification
-    channels.each do |channel|
-      send_webook_post(channel)
-    end
+    channels.each { |channel| send_webook_post(channel) }
   end
 
   def body(channel)
@@ -36,7 +34,7 @@ class WebhookNotifier
   end
 
   def send_webook_post(channel)
-    uri = URI(channel.webhook_url)
+    uri = URI(ENV.fetch("SLACK_POST_WEBHOOK_URL"))
     Net::HTTP.start(
       uri.host,
       uri.port,

--- a/db/migrate/20150726050435_remove_webhook_url_from_channels.rb
+++ b/db/migrate/20150726050435_remove_webhook_url_from_channels.rb
@@ -1,0 +1,5 @@
+class RemoveWebhookUrlFromChannels < ActiveRecord::Migration
+  def change
+    remove_column :channels, :webhook_url, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,14 +11,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150313144216) do
+ActiveRecord::Schema.define(version: 20150726050435) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "channels", force: :cascade do |t|
-    t.string "name",        null: false
-    t.string "webhook_url", null: false
+    t.string "name", null: false
   end
 
   add_index "channels", ["name"], name: "index_channels_on_name", using: :btree

--- a/spec/controllers/github_payloads_controller_spec.rb
+++ b/spec/controllers/github_payloads_controller_spec.rb
@@ -52,13 +52,11 @@ describe GithubPayloadsController do
       end
 
       it "posts to slack" do
-        create(
-          :channel,
-          name: "ruby",
-          webhook_url: "https://google.com/",
-          tag_name: "rails",
-        )
-        request_stub = stub_request(:post, "https://google.com/").with(body: /.*/)
+        create(:channel, name: "ruby", tag_name: "rails")
+        request_stub = stub_request(
+          :post,
+          ENV.fetch("SLACK_POST_WEBHOOK_URL")
+        ).with(body: /"channel":"ruby"/)
 
         send_pull_request_payload(action: "opened", body: "A request #rails")
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,7 +1,6 @@
 FactoryGirl.define do
   factory :channel do
     sequence(:name) { |n| "channel#{n}" }
-    webhook_url "http://example.com/home"
 
     transient do
       tag_name nil

--- a/spec/models/channel_spec.rb
+++ b/spec/models/channel_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 describe Channel do
   it { should validate_presence_of(:name) }
-  it { should validate_presence_of(:webhook_url) }
 
   it { should have_many(:projects).dependent(:destroy) }
   it { should have_many(:tags).dependent(:destroy) }


### PR DESCRIPTION
Slack's Incoming Webhooks API makes it easy
to specify a channel to post to by name.

Taking advantage of that feature means we no longer have to set up
different incoming webhook integrations for each channel - we can
use a single incoming webhook, and provide the channel name whenever we
post to Slack.
