### PR TITLE
Display real comment count for each PR

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -360,3 +360,6 @@ DEPENDENCIES
   uglifier
   unicorn
   webmock
+
+BUNDLED WITH
+   1.10.3

--- a/app/services/payload_parser.rb
+++ b/app/services/payload_parser.rb
@@ -31,15 +31,16 @@ class PayloadParser
 
   def params
     {
-      github_url: github_url,
-      repo_name: repo_name,
-      repo_github_url: repo_github_url,
-      title: title,
-      user_name: user_name,
-      user_github_url: user_github_url,
-      avatar_url: avatar_url,
       additions: additions,
+      avatar_url: avatar_url,
+      comment_count: comment_count,
       deletions: deletions,
+      github_url: github_url,
+      repo_github_url: repo_github_url,
+      repo_name: repo_name,
+      title: title,
+      user_github_url: user_github_url,
+      user_name: user_name,
     }
   end
 
@@ -75,6 +76,13 @@ class PayloadParser
 
   def deletions
     pull_request["deletions"]
+  end
+
+  def comment_count
+    [
+      pull_request["comments"],
+      pull_request["review_comments"],
+    ].sum
   end
 
   def pull_request

--- a/app/views/pull_requests/_pull_request.html.erb
+++ b/app/views/pull_requests/_pull_request.html.erb
@@ -27,7 +27,7 @@
   <div class="table-list-cell hide-mobile">
     <div class="comment-count">
       <%= embedded_svg "svg/comment.svg" %>
-      <span class="dummy">1</span>
+      <span data-role="comment-count"><%= pull_request.comment_count %></span>
     </div>
   </div>
 </li>

--- a/db/migrate/20150925165001_add_comment_count_to_pull_requests.rb
+++ b/db/migrate/20150925165001_add_comment_count_to_pull_requests.rb
@@ -1,0 +1,5 @@
+class AddCommentCountToPullRequests < ActiveRecord::Migration
+  def change
+    add_column :pull_requests, :comment_count, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150714160637) do
+ActiveRecord::Schema.define(version: 20150925165001) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,6 +66,7 @@ ActiveRecord::Schema.define(version: 20150714160637) do
     t.integer  "additions",       default: 0,                                                         null: false
     t.integer  "deletions",       default: 0,                                                         null: false
     t.datetime "reposted_at"
+    t.integer  "comment_count",   default: 0,                                                         null: false
   end
 
   add_index "pull_requests", ["status"], name: "index_pull_requests_on_status", using: :btree

--- a/spec/features/user_views_prs_spec.rb
+++ b/spec/features/user_views_prs_spec.rb
@@ -35,6 +35,7 @@ feature "User views PRs" do
        user_github_url: "https://github.com/joelq",
        github_url: "https://github.com/org/repo/pulls/123",
        avatar_url: "http://myavatar.com",
+       comment_count: 3,
     )
 
     visit root_path
@@ -42,6 +43,7 @@ feature "User views PRs" do
     expect(page).to have_content("#123 opened about 1 hour ago by JoelQ")
     expect(page).to have_link("JoelQ", href: "https://github.com/joelq")
     expect(page).to have_avatar("http://myavatar.com")
+    expect(page).to have_selector("[data-role='comment-count']", text: "3")
   end
 
   scenario "viewing tags for the current pr" do

--- a/spec/services/payload_parser_spec.rb
+++ b/spec/services/payload_parser_spec.rb
@@ -42,5 +42,15 @@ describe PayloadParser do
       expect(parser.params[:additions]).to eq(1)
       expect(parser.params[:deletions]).to eq(20)
     end
+
+    it "calculates the number of comments" do
+      payload = JSON.parse(
+        pull_request_payload(comments: 2, review_comments: 3)
+      )
+
+      parser = PayloadParser.new(payload, nil)
+
+      expect(parser.params[:comment_count]).to eq(5)
+    end
   end
 end

--- a/spec/support/github_payloads/pull_request_payload.rb
+++ b/spec/support/github_payloads/pull_request_payload.rb
@@ -5,7 +5,9 @@ def pull_request_payload(
   user_name: "someone_else",
   avatar_url: "http://avatar.com",
   additions: 5,
-  deletions: 10
+  deletions: 10,
+  comments: 0,
+  review_comments: 1
 )
 <<-EOS
 {
@@ -306,8 +308,8 @@ def pull_request_payload(
       "mergeable":true,
       "mergeable_state":"clean",
       "merged_by":null,
-      "comments":0,
-      "review_comments":1,
+      "comments":#{comments},
+      "review_comments":#{review_comments},
       "commits":1,
       "additions":#{additions},
       "deletions":#{deletions},


### PR DESCRIPTION
To get this count, we actually have to sum up the number of comments on the PR
itself plus whatever was inlined.

Fixes #64
