### PR TITLE
Skip auth for API requests

### DIFF
--- a/app/controllers/pull_requests_controller.rb
+++ b/app/controllers/pull_requests_controller.rb
@@ -1,9 +1,10 @@
 class PullRequestsController < ApplicationController
   helper_method :grouped_pull_requests, :tags, :tags_to_filter_by
+  skip_before_filter :ensure_thoughtbot_team, only: :index
 
   def index
     respond_to do |format|
-      format.html
+      format.html { ensure_thoughtbot_team }
       format.json { render json: pull_requests }
     end
   end


### PR DESCRIPTION
Requiring authentication is more work than it is worth in this case. We aren't exposing any sensitive information by only providing a PR link.
