### PR TITLE
Tag classnames should always be lowercase

### DIFF
--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -8,7 +8,7 @@ module TagsHelper
   end
 
   def tag_classes(tag)
-    classes = ["tag-toggle", tag]
+    classes = ["tag-toggle", tag.downcase]
 
     if active_tag?(tag)
       classes << "is-active"


### PR DESCRIPTION
The development seeds have tags that are title case: "Ember", "Rails",
etc. As such, the tags had the classnames `Ember`, `Rails`.

This change forces tags to use the downcase for classnames.
