### PR TITLE
Eliminate the need for a HABTM between channels and pull requests

### DIFF
--- a/app/actions/create_new_pr.rb
+++ b/app/actions/create_new_pr.rb
@@ -31,28 +31,7 @@ class CreateNewPr
   end
 
   def pull_request_params
-    payload_parser.params.merge(
-      channels: channels,
-      tags: tags,
-    )
-  end
-
-  def channels
-    [tag_channels, project_channels].flatten.compact
-  end
-
-  def project_channels
-    @projects ||= begin
-      projects = ProjectMatcher.match(payload_parser.repo_github_url)
-      unique_channels(list: projects, method: :default_channel)
-    end
-  end
-
-  def tag_channels
-    @tag_channels ||= unique_channels(
-      list: tag_names,
-      method: Channel.method(:with_tag_name),
-    )
+    payload_parser.params.merge(tags: tags)
   end
 
   def tags
@@ -65,9 +44,5 @@ class CreateNewPr
 
   def post_to_slack(pull_request)
     WebhookNotifier.new(pull_request).send_notification
-  end
-
-  def unique_channels(list:, method:)
-    list.map(&method).compact.uniq
   end
 end

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -5,7 +5,10 @@ class Channel < ActiveRecord::Base
 
   has_many :projects, as: :default_channel, dependent: :destroy
   has_many :tags, dependent: :destroy
-  has_and_belongs_to_many :active_pull_requests, -> { active }, class_name: "PullRequest"
+  has_many :active_pull_requests,
+    -> { active },
+    through: :tags,
+    source: :pull_requests
 
   def self.with_active_pull_requests
     joins(:active_pull_requests).uniq

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -10,8 +10,8 @@ class PullRequest < ActiveRecord::Base
   validates :user_github_url, presence: true
   validates :avatar_url, presence: true
 
-  has_and_belongs_to_many :channels
   has_and_belongs_to_many :tags
+  has_many :channels, through: :tags
 
   time_for_a_boolean :reposted
 
@@ -21,8 +21,7 @@ class PullRequest < ActiveRecord::Base
 
   def self.for_tags(tag_names)
     if tag_names.present?
-      joins(channels: :tags).
-        where(tags: { name: tag_names })
+      joins(:tags).where(tags: { name: tag_names })
     else
       all
     end

--- a/db/migrate/20151002193350_drop_channels_pull_requests.rb
+++ b/db/migrate/20151002193350_drop_channels_pull_requests.rb
@@ -1,0 +1,23 @@
+class DropChannelsPullRequests < ActiveRecord::Migration
+  def up
+    drop_table :channels_pull_requests
+  end
+
+  def down
+    create_table :channels_pull_requests do |t|
+      t.belongs_to :channel
+      t.belongs_to :pull_request
+    end
+
+    add_index :channels_pull_requests,
+      [:channel_id, :pull_request_id],
+      unique: true
+
+    execute <<-EOS
+      INSERT INTO channels_pull_requests (channel_id, pull_request_id)
+      SELECT tags.channel_id, pull_requests_tags.pull_request_id
+      FROM tags, pull_requests_tags
+      WHERE tags.id = pull_requests_tags.tag_id
+    EOS
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150925165001) do
+ActiveRecord::Schema.define(version: 20151002193350) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,13 +22,6 @@ ActiveRecord::Schema.define(version: 20150925165001) do
   end
 
   add_index "channels", ["name"], name: "index_channels_on_name", using: :btree
-
-  create_table "channels_pull_requests", force: :cascade do |t|
-    t.integer "channel_id"
-    t.integer "pull_request_id"
-  end
-
-  add_index "channels_pull_requests", ["channel_id", "pull_request_id"], name: "index_channels_pull_requests_on_channel_id_and_pull_request_id", unique: true, using: :btree
 
   create_table "delayed_jobs", force: :cascade do |t|
     t.integer  "priority",   default: 0, null: false

--- a/spec/actions/create_new_pr_spec.rb
+++ b/spec/actions/create_new_pr_spec.rb
@@ -44,63 +44,6 @@ describe CreateNewPr do
     end
   end
 
-  describe ".channels" do
-    context "when there is a project" do
-      it "includes the project default channel and any tags" do
-        rails_channel = create(:channel, tag_name: "rails")
-        design_channel = create(:channel, tag_name: "design")
-        project_channel = create(:channel, name: "project")
-
-        project_url = "https://github.com/thoughtbot/beggar"
-        create(
-          :project,
-          github_url: project_url,
-          default_channel: project_channel
-        )
-
-        parser = double(
-          :parser,
-          action: "opened",
-          body: "#rails #design",
-          params: attributes_for(:pull_request),
-          repo_github_url: project_url
-        )
-
-        pr_creator = CreateNewPr.new(parser, nil)
-        allow(pr_creator).to receive(:post_to_slack)
-
-        pr_creator.call
-
-        pr = PullRequest.last
-        channels = [rails_channel, design_channel, project_channel]
-        expect(pr.channels).to match_array(channels)
-      end
-    end
-
-    context "when there isn't a project" do
-      it "includes channels based on tags" do
-        rails_channel = create(:channel, tag_name: "rails")
-        design_channel = create(:channel, tag_name: "design")
-        parser = double(
-          :parser,
-          action: "opened",
-          body: "#rails #design",
-          params: attributes_for(:pull_request),
-          repo_github_url: "_"
-        )
-        pr_creator = CreateNewPr.new(parser, nil)
-        allow(pr_creator).to receive(:post_to_slack)
-
-        pr_creator.call
-
-        pull_request = PullRequest.last
-
-        channels = [rails_channel, design_channel]
-        expect(pull_request.channels).to match_array(channels)
-      end
-    end
-  end
-
   describe ".tags" do
     it "creates the pull request with the original tags" do
       rails = create(:tag, name: "rails")

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -47,11 +47,9 @@ FactoryGirl.define do
 
     after(:create) do |pull_request, evaluator|
       evaluator.tag_names.each do |tag_name|
-        create(
-          :channel,
-          tag_name: tag_name,
-          active_pull_requests: [pull_request]
-        )
+        unless Tag.exists?(name: tag_name)
+          create(:tag, name: tag_name, pull_requests: [pull_request])
+        end
       end
     end
   end

--- a/spec/features/user_views_prs_spec.rb
+++ b/spec/features/user_views_prs_spec.rb
@@ -71,18 +71,18 @@ feature "User views PRs" do
   end
 
   scenario "Sees tags with active pull requests" do
-    rails = channel("rails")
-    ember = channel("ember")
+    rails = tag("rails")
+    ember = tag("ember")
     create(
       :pull_request,
       title: "An Ember PR",
-      channels: [ember],
+      tags: [ember],
       status: "completed"
     )
     create(
       :pull_request,
       title: "A Rails PR",
-      channels: [rails],
+      tags: [rails],
       status: "needs review"
     )
 
@@ -136,11 +136,11 @@ feature "User views PRs" do
   private
 
   def create_pull_requests_with_tags
-    ember = channel("ember")
-    rails = channel("rails")
-    create(:pull_request, title: "An Ember PR", channels: [ember])
-    create(:pull_request, title: "A Rails PR", channels: [rails])
-    create(:pull_request, title: "A long pr", channels: [rails, ember])
+    ember = tag("ember")
+    rails = tag("rails")
+    create(:pull_request, title: "An Ember PR", tags: [ember])
+    create(:pull_request, title: "A Rails PR", tags: [rails])
+    create(:pull_request, title: "A long pr", tags: [rails, ember])
   end
 
   def have_avatar(url)
@@ -149,10 +149,6 @@ feature "User views PRs" do
 
   def have_tag(tag_name)
     have_css("[data-role='tag']", text: tag_name)
-  end
-
-  def channel(name)
-    create(:channel, name: name, tag_name: name)
   end
 
   def tag(name)

--- a/spec/models/channel_spec.rb
+++ b/spec/models/channel_spec.rb
@@ -7,7 +7,19 @@ describe Channel do
 
   it { should have_many(:projects).dependent(:destroy) }
   it { should have_many(:tags).dependent(:destroy) }
-  it { should have_and_belong_to_many(:active_pull_requests) }
+  it { should have_many(:active_pull_requests).through(:tags) }
+
+  describe ".with_active_pull_requests" do
+    it "returns a unique list of active pull requests" do
+      channel = create(:channel, name: "cool_project")
+      rails_tag = create(:tag, name: "rails", channel: channel)
+      ember_tag = create(:tag, name: "ember", channel: channel)
+      create(:pull_request, status: "in progress", tags: [rails_tag, ember_tag])
+      create(:pull_request, status: "completed", tags: [rails_tag])
+
+      expect(Channel.with_active_pull_requests).to eq([channel])
+    end
+  end
 
   describe ".with_tag_name" do
     it "will return the channel with the given tag name" do

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -10,18 +10,18 @@ describe PullRequest do
   it { should validate_presence_of(:user_github_url) }
   it { should validate_presence_of(:avatar_url) }
 
-  it { should have_and_belong_to_many(:channels) }
+  it { should have_many(:channels).through(:tags) }
   it { should have_and_belong_to_many(:tags) }
 
   describe ".for_tag" do
     it "returns all the pull requests for a matching tag name" do
-      ruby = create(:channel, tag_name: "ruby")
-      javascript = create(:channel, tag_name: "javascript")
-      osx = create(:channel, tag_name: "osx")
+      ruby = create(:tag, name: "ruby")
+      javascript = create(:tag, name: "javascript")
+      osx = create(:tag, name: "osx")
 
-      ruby_pr = create(:pull_request, channels: [ruby])
-      javascript_pr = create(:pull_request, channels: [javascript])
-      _osx_pr = create(:pull_request, channels: [osx])
+      ruby_pr = create(:pull_request, tags: [ruby])
+      javascript_pr = create(:pull_request, tags: [javascript])
+      _osx_pr = create(:pull_request, tags: [osx])
 
       matching_prs = PullRequest.for_tags(["ruby", "javascript"])
 


### PR DESCRIPTION
Channels are always accessible through tags, so it's excessive to have a direct association between channels and pull requests.
