### PR TITLE
Improve the setup page

### DIFF
--- a/app/assets/stylesheets/base/_tables.scss
+++ b/app/assets/stylesheets/base/_tables.scss
@@ -6,14 +6,14 @@ table {
 }
 
 th {
-  border-bottom: 1px solid darken($base-border-color, 15);
+  border-bottom: $base-border;
   font-weight: bold;
   padding: ($base-spacing / 2) 0;
   text-align: left;
 }
 
 td {
-  border-bottom: $base-border;
+  border-bottom: $light-border;
   padding: ($base-spacing / 2) 0;
 }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,7 +5,7 @@ module ApplicationHelper
     render file: file.pathname
   end
 
-  def all_tag_names
-    Tag.order(:name).pluck("DISTINCT name")
+  def all_tags_channels
+    Tag.joins(:channel).order(:name).pluck("tags.name", "channels.name")
   end
 end

--- a/app/views/pages/setup.html.erb
+++ b/app/views/pages/setup.html.erb
@@ -19,26 +19,47 @@
   <div class="content">
     <section>
       <h2>What is Beggar?</h2>
-      <p>Beggar is a tool to help with getting pull request reviews. Once you have set up Beggar on your repo, any new pull request will automatically be added to Beggar. It will also automatically be posted to the correct Slack room based on the tags you've provided.</p>
-      <p>To make sure your PR goes to the correct place, your PR description should include tags like #rails #javascript #design. Beggar will parse and send to all the appropriate rooms!</p>
-      <p>Tags you can use currently:</p>
-      <ul>
-        <% all_tag_names.each do |tag| %>
-          <li><%= tag %></li>
-        <% end %>
-      </ul>
+      <p>Beggar is a tool to help get your pull requests reviewed. Once
+      configured, pull requests with a matching <code>#tag</code> will be added
+      to the Beggar UI and the appropriate Slack channel.</p>
+      <p>New PRs have a "Needs Review" status. Once there are one or more
+      comments, it will be moved to to "In Progress".</p>
+      <p>Any comment containing <code>LGTM</code> will consider the PR
+      closed.</p>
+      <p>Any comment containing <code>NRR</code> (needs re-review) will kick
+      it back to "Needs Review".</p>
     </section>
 
     <section>
-      <h2>Setup: Add the Webhook</h2>
+      <h2>Setup: Tags and Channels</h2>
+      <p>Configure tags and channels in the <%= link_to "Admin Panel", admin_root_path %>.</p>
+      <p>The currently-enabled tags and their associated channels are:</p>
+      <table>
+        <tr>
+          <th>Tag</th>
+          <th>Slack Channel</th>
+        </tr>
+        <% all_tags_channels.each do |tag, channel| %>
+          <tr>
+            <td>#<%= tag %></td>
+            <td><%= channel %></td>
+          </tr>
+        <% end %>
+      </table>
+    </section>
+
+    <section>
+      <h2>Setup: Add the Webhook to your GitHub repo</h2>
       <ol>
         <li>Visit <code>https://github.com/$ORGANIZATION/$REPO/settings/hooks/new</code>.</li>
         <li>Enter <code><%= ENV["WEBHOOK_URL"] %></code> for the Payload URL.</li>
         <li>Enter <code><%= ENV["GITHUB_SECRET_KEY"] %></code> for the secret.</li>
         <li>Select <code>Send me everything</code>, and submit.</li>
-        <li>Submit a PR! It will be added to the Beggar UI, and if given a <code>#tag</code> in the description, will be posted to the appropriate Slack channel.</li>
-        <p>Any comment containing <code>LGTM</code> will consider the PR closed.</p>
-        <p>Any comment containing <code>NRR</code> (needs re-review) will kick it back to "Needs Review".</p>
+        <li>
+          <p>Submit a PR! When given a matching <code>#tag</code> in the
+          description, it will be posted to both the Beggar UI and its
+          associated Slack channel.</p>
+        </li>
       </ol>
     </section>
 


### PR DESCRIPTION
![screencapture-localhost-8000-pages-setup-1445624692098](https://cloud.githubusercontent.com/assets/2317604/10701559/25694318-7992-11e5-9c58-2e5a373f7821.png)
- List the configured channels (in addition to their tags)
- Mention the Admin section for tag/channel configuration
- Reorganize content, so the setup steps don't recommend you `#tag` a PR before you've added tags
