### PR TITLE
Lowercase tag classname

### DIFF
--- a/app/views/pull_requests/_pull_request.html.erb
+++ b/app/views/pull_requests/_pull_request.html.erb
@@ -20,7 +20,7 @@
 
   <div class="table-list-cell hide-mobile">
     <% pull_request.tags.each do |tag| %>
-      <span class="tag <%= tag.name %>" data-role="tag"><%= tag.name %></span>
+      <span class="tag <%= tag.name.downcase %>" data-role="tag"><%= tag.name %></span>
     <% end %>
   </div>
 


### PR DESCRIPTION
Locally, tag names are not picking up their styling because the tag's name is titleized, but the CSS expects a lowercase classname.

With this change, we would be downcasing the tag name in two places, here and [here](https://github.com/thoughtbot/beggar/blob/73a973c061d7d04710468b96aec63b0fa43b34c1/app/helpers/tags_helper.rb#L11).

Should we instead make them lowercase when added, and update the seeds to reflect the change?
