### PR TITLE
Always downcase tag names

### DIFF
--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -8,7 +8,7 @@ module TagsHelper
   end
 
   def tag_classes(tag)
-    classes = ["tag-toggle", tag.downcase]
+    classes = ["tag-toggle", tag]
 
     if active_tag?(tag)
       classes << "is-active"

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -4,9 +4,19 @@ class Tag < ActiveRecord::Base
   validates :name, presence: true
   validates :name, uniqueness: true
 
+  before_validation :normalize_name
+
   belongs_to :channel
 
   has_and_belongs_to_many :pull_requests
 
   delegate :count, to: :pull_requests, prefix: true
+
+  private
+
+  def normalize_name
+    if name.present?
+      self.name = name.downcase
+    end
+  end
 end

--- a/app/views/tags/_tag.html.erb
+++ b/app/views/tags/_tag.html.erb
@@ -1,6 +1,6 @@
 <li>
   <%= link_to(toggle_tag_on_path(tag.name), class: tag_classes(tag.name)) do %>
-    <%= tag.name.titleize %>
+    <%= tag.name %>
     <span class="tag-badge" data-role="pr-count"><%= tag.pull_requests_count %></span>
   <% end %>
 </li>

--- a/spec/features/user_views_prs_spec.rb
+++ b/spec/features/user_views_prs_spec.rb
@@ -49,13 +49,13 @@ feature "User views PRs" do
   scenario "viewing tags for the current pr" do
     create(
       :pull_request,
-      tags: [tag("Rails"), tag("Ember")],
+      tags: [tag("rails"), tag("ember")],
     )
 
     visit root_path
 
-    expect(page).to have_tag("Rails")
-    expect(page).to have_tag("Ember")
+    expect(page).to have_tag("rails")
+    expect(page).to have_tag("ember")
   end
 
   scenario "Does not see completed PRs" do
@@ -89,8 +89,8 @@ feature "User views PRs" do
     visit root_path
 
     within(".tags") do
-      expect(page).to have_content("Rails")
-      expect(page).not_to have_content("Ember")
+      expect(page).to have_content("rails")
+      expect(page).not_to have_content("ember")
       expect(page).to have_selector("[data-role='pr-count']", text: "1")
     end
   end
@@ -100,7 +100,7 @@ feature "User views PRs" do
 
     visit root_path
     within(".tags") do
-      click_on "Ember"
+      click_on "ember"
     end
 
     expect(page).to have_content("An Ember PR")
@@ -113,7 +113,7 @@ feature "User views PRs" do
 
     visit root_path(tags: "ember")
     within(".tags") do
-      click_on "Rails"
+      click_on "rails"
     end
 
     expect(page).to have_content("An Ember PR")
@@ -126,7 +126,7 @@ feature "User views PRs" do
 
     visit root_path(tags: "ember,rails")
     within(".tags") do
-      click_on "Ember"
+      click_on "ember"
     end
 
     expect(page).not_to have_content("An Ember PR")

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -15,4 +15,9 @@ describe Tag do
     validation_errors = new_tag.errors.full_messages
     expect(validation_errors).to include("Name has already been taken")
   end
+
+  it "downcases the tag name before saving" do
+    tag = create(:tag, name: "UPCASE")
+    expect(tag.reload.name).to eq("upcase")
+  end
 end


### PR DESCRIPTION
Siding with lowercased tag names across the board.

This also reverts commit 73a973c, "Tag classnames should always be lowercase".

Fixes #109
