### PR TITLE
Show filters based on active PRs for a tag, not through channels

### DIFF
--- a/app/controllers/pull_requests_controller.rb
+++ b/app/controllers/pull_requests_controller.rb
@@ -20,7 +20,7 @@ class PullRequestsController < ApplicationController
   end
 
   def tags
-    @tags ||= Channel.with_active_pull_requests.flat_map(&:tags)
+    @tags ||= Tag.with_active_pull_requests
   end
 
   def tags_to_filter_by

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -10,10 +10,6 @@ class Channel < ActiveRecord::Base
     through: :tags,
     source: :pull_requests
 
-  def self.with_active_pull_requests
-    joins(:active_pull_requests).uniq
-  end
-
   def self.with_tag_name(tag_names)
     joins(:tags).find_by(tags: { name: tag_names })
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -12,6 +12,12 @@ class Tag < ActiveRecord::Base
 
   delegate :count, to: :pull_requests, prefix: true
 
+  def self.with_active_pull_requests
+    joins(:pull_requests).
+      merge(PullRequest.active).
+      uniq
+  end
+
   private
 
   def normalize_name

--- a/spec/models/channel_spec.rb
+++ b/spec/models/channel_spec.rb
@@ -9,18 +9,6 @@ describe Channel do
   it { should have_many(:tags).dependent(:destroy) }
   it { should have_many(:active_pull_requests).through(:tags) }
 
-  describe ".with_active_pull_requests" do
-    it "returns a unique list of active pull requests" do
-      channel = create(:channel, name: "cool_project")
-      rails_tag = create(:tag, name: "rails", channel: channel)
-      ember_tag = create(:tag, name: "ember", channel: channel)
-      create(:pull_request, status: "in progress", tags: [rails_tag, ember_tag])
-      create(:pull_request, status: "completed", tags: [rails_tag])
-
-      expect(Channel.with_active_pull_requests).to eq([channel])
-    end
-  end
-
   describe ".with_tag_name" do
     it "will return the channel with the given tag name" do
       matching_channel = create(:channel)

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -20,4 +20,15 @@ describe Tag do
     tag = create(:tag, name: "UPCASE")
     expect(tag.reload.name).to eq("upcase")
   end
+
+  describe ".with_active_pull_requests" do
+    it "returns a unique list of active pull requests" do
+      rails_tag = create(:tag, name: "rails")
+      ember_tag = create(:tag, name: "ember")
+      create(:pull_request, status: "in progress", tags: [ember_tag])
+      create(:pull_request, status: "completed", tags: [rails_tag])
+
+      expect(Tag.with_active_pull_requests).to eq([ember_tag])
+    end
+  end
 end


### PR DESCRIPTION
Instead of fetching the tag names through channels, we should just use the Tag
model directly to figure out which still has active pull requests.

Fixes #110
