### PR TITLE
Abstract team

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,13 +2,13 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :null_session
-  before_filter :ensure_thoughtbot_team
+  before_filter :ensure_team_member
   force_ssl if: :ssl_configured?
 
 
   private
 
-  def ensure_thoughtbot_team
+  def ensure_team_member
     unless github_username || Rails.env.test?
       redirect_to new_session_path
     end

--- a/app/controllers/github_payloads_controller.rb
+++ b/app/controllers/github_payloads_controller.rb
@@ -1,6 +1,6 @@
 class GithubPayloadsController < ApplicationController
   before_action VerifyGithubSignature.new(ENV["GITHUB_SECRET_KEY"])
-  skip_before_filter :ensure_thoughtbot_team
+  skip_before_filter :ensure_team_member
 
   def create
     action_matching(parser, pull_request).call

--- a/app/controllers/pull_requests_controller.rb
+++ b/app/controllers/pull_requests_controller.rb
@@ -1,10 +1,10 @@
 class PullRequestsController < ApplicationController
   helper_method :grouped_pull_requests, :tags, :tags_to_filter_by
-  skip_before_filter :ensure_thoughtbot_team, only: :index
+  skip_before_filter :ensure_team_member, only: :index
 
   def index
     respond_to do |format|
-      format.html { ensure_thoughtbot_team }
+      format.html { ensure_team_member }
       format.json { render json: pull_requests }
     end
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,5 @@
 class SessionsController < ApplicationController
-  skip_before_filter :ensure_thoughtbot_team
+  skip_before_filter :ensure_team_member
 
   def new
 
@@ -10,7 +10,8 @@ class SessionsController < ApplicationController
       session[:github_username] = github_username
       redirect_to root_path
     else
-      flash[:error] = "You cannot access this site unless you are a member of the thoughtbot team"
+      flash[:error] = "You cannot access this site" \
+                      "unless you are a member of the team"
       redirect_to root_path
     end
   end


### PR DESCRIPTION
When I was working on setting up the project for our team, I made a mistake which resulted in having this error on the screen:

```
You cannot access this site unless you are a member of the thoughtbot team
```

I was a little bit confused. After digging into the code, I realized that it is a hard-coded thing. :smile: 

This PR makes the meaning of the team more abstract in order to avoid confusions. :wink: 

