### PR TITLE
Exclude completed PRs while counting a number of PRs by a tag

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -10,12 +10,14 @@ class Tag < ActiveRecord::Base
 
   has_and_belongs_to_many :pull_requests
 
-  delegate :count, to: :pull_requests, prefix: true
-
   def self.with_active_pull_requests
     joins(:pull_requests).
       merge(PullRequest.active).
       uniq
+  end
+
+  def pull_requests_count
+    pull_requests.active.count
   end
 
   private

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -13,6 +13,15 @@ describe PullRequest do
   it { should have_many(:channels).through(:tags) }
   it { should have_and_belong_to_many(:tags) }
 
+  describe ".active" do
+    it "returns active pull requests" do
+      active = create(:pull_request, status: "in progress")
+      _completed = create(:pull_request, status: "completed")
+
+      expect(PullRequest.active).to eq([active])
+    end
+  end
+
   describe ".for_tag" do
     it "returns all the pull requests for a matching tag name" do
       ruby = create(:tag, name: "ruby")

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -31,14 +31,4 @@ describe Tag do
       expect(Tag.with_active_pull_requests).to eq([ember_tag])
     end
   end
-
-  describe "#pull_requests_count" do
-    it "returns a number of active pull requests" do
-      rails_tag = create(:tag, name: "rails")
-      create(:pull_request, status: "in progress", tags: [rails_tag])
-      create(:pull_request, status: "completed", tags: [rails_tag])
-
-      expect(rails_tag.pull_requests_count).to eq(1)
-    end
-  end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -31,4 +31,14 @@ describe Tag do
       expect(Tag.with_active_pull_requests).to eq([ember_tag])
     end
   end
+
+  describe "#pull_requests_count" do
+    it "returns a number of active pull requests" do
+      rails_tag = create(:tag, name: "rails")
+      create(:pull_request, status: "in progress", tags: [rails_tag])
+      create(:pull_request, status: "completed", tags: [rails_tag])
+
+      expect(rails_tag.pull_requests_count).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
After playing with the Pester, I noticed this bug:

![pester-bug](https://cloud.githubusercontent.com/assets/128024/19808177/3549807c-9d2c-11e6-9a8b-3ae2ea0734bd.png)

The tag shows that there are 3 PRs, but actually, there is only one. :wink:  This PR fixes the bug.
