### PR TITLE
Upgrade the capybara-webkit dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,14 +68,15 @@ GEM
       bundler (~> 1.2)
       thor (~> 0.18)
     byebug (8.2.1)
-    capybara (2.5.0)
+    capybara (2.13.0)
+      addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    capybara-webkit (1.7.1)
-      capybara (>= 2.3.0, < 2.6.0)
+    capybara-webkit (1.14.0)
+      capybara (>= 2.3.0, < 2.14.0)
       json
     coderay (1.1.0)
     coffee-rails (4.1.0)
@@ -154,7 +155,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (5.0.5)
       railties (>= 3.2.16)
-    json (1.8.3)
+    json (1.8.6)
     jwt (1.5.2)
     kaminari (0.16.3)
       actionpack (>= 3.0.0)
@@ -167,8 +168,8 @@ GEM
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
-    mime-types (2.99)
-    mini_portile2 (2.0.0)
+    mime-types (2.99.3)
+    mini_portile2 (2.1.0)
     minitest (5.8.3)
     multi_json (1.11.2)
     multi_xml (0.5.5)
@@ -177,8 +178,8 @@ GEM
       bourbon (>= 4.0)
       sass (>= 3.3)
     newrelic_rpm (3.14.1.311)
-    nokogiri (1.6.7)
-      mini_portile2 (~> 2.0.0.rc2)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
     normalize-rails (3.0.3)
     oauth2 (1.0.0)
       faraday (>= 0.8, < 0.10)
@@ -208,7 +209,7 @@ GEM
       slop (~> 3.4)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
-    rack (1.6.4)
+    rack (1.6.8)
     rack-test (0.6.3)
       rack (>= 1.0)
     rack-timeout (0.3.2)
@@ -319,7 +320,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    xpath (2.0.0)
+    xpath (2.1.0)
       nokogiri (~> 1.3)
 
 PLATFORMS
@@ -369,5 +370,8 @@ DEPENDENCIES
   unicorn
   webmock
 
+RUBY VERSION
+   ruby 2.2.3p173
+
 BUNDLED WITH
-   1.10.6
+   1.16.1


### PR DESCRIPTION
Nokogiri has a security issue so this needs to be bumped ASAP.